### PR TITLE
all: conform build tag comment to Go convention

### DIFF
--- a/example/psenvpub.go
+++ b/example/psenvpub.go
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-//+build ignore
+// +build ignore
 
 // PubSub envelope publisher
 package main

--- a/example/psenvsub.go
+++ b/example/psenvsub.go
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-//+build ignore
+// +build ignore
 
 // PubSub envelope subscriber
 package main

--- a/example/rrclient.go
+++ b/example/rrclient.go
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-//+build ignore
+// +build ignore
 
 // Request-reply client.
 //

--- a/example/rrworker.go
+++ b/example/rrworker.go
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-//+build ignore
+// +build ignore
 
 // Request-reply worker.
 //

--- a/example/rtdealer.go
+++ b/example/rtdealer.go
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-//+build ignore
+// +build ignore
 
 // Router/Dealer example.
 package main


### PR DESCRIPTION
Done mechanically with:

```
 $> sed -i -e 's|//+build|// +build|' $(grep -l '//+build' -R|grep \.go$)
```