### PR TITLE
zmq4: provide Socket.Addr() interface

### DIFF
--- a/cxx_zmq4_compat.go
+++ b/cxx_zmq4_compat.go
@@ -126,6 +126,12 @@ func (sck *csocket) Type() SocketType {
 	panic("invalid C-socket type")
 }
 
+// Addr returns the listener's address.
+// Addr returns nil if the socket isn't a listener.
+func (sck *csocket) Addr() net.Addr {
+	panic("not implemented")
+}
+
 // Conn returns the underlying net.Conn the socket is bound to.
 func (sck *csocket) Conn() net.Conn {
 	panic("not implemented")

--- a/dealer.go
+++ b/dealer.go
@@ -6,6 +6,7 @@ package zmq4
 
 import (
 	"context"
+	"net"
 )
 
 // NewDealer returns a new DEALER ZeroMQ socket.
@@ -49,6 +50,12 @@ func (dealer *dealerSocket) Dial(ep string) error {
 // Type returns the type of this Socket (PUB, SUB, ...)
 func (dealer *dealerSocket) Type() SocketType {
 	return dealer.sck.Type()
+}
+
+// Addr returns the listener's address.
+// Addr returns nil if the socket isn't a listener.
+func (dealer *dealerSocket) Addr() net.Addr {
+	return dealer.sck.Addr()
 }
 
 // GetOption is used to retrieve an option for a socket.

--- a/pair.go
+++ b/pair.go
@@ -6,6 +6,7 @@ package zmq4
 
 import (
 	"context"
+	"net"
 )
 
 // NewPair returns a new PAIR ZeroMQ socket.
@@ -49,6 +50,12 @@ func (pair *pairSocket) Dial(ep string) error {
 // Type returns the type of this Socket (PUB, SUB, ...)
 func (pair *pairSocket) Type() SocketType {
 	return pair.sck.Type()
+}
+
+// Addr returns the listener's address.
+// Addr returns nil if the socket isn't a listener.
+func (pair *pairSocket) Addr() net.Addr {
+	return pair.sck.Addr()
 }
 
 // GetOption is used to retrieve an option for a socket.

--- a/pub.go
+++ b/pub.go
@@ -6,6 +6,7 @@ package zmq4
 
 import (
 	"context"
+	"net"
 	"sync"
 
 	"golang.org/x/sync/errgroup"
@@ -58,6 +59,12 @@ func (pub *pubSocket) Dial(ep string) error {
 // Type returns the type of this Socket (PUB, SUB, ...)
 func (pub *pubSocket) Type() SocketType {
 	return pub.sck.Type()
+}
+
+// Addr returns the listener's address.
+// Addr returns nil if the socket isn't a listener.
+func (pub *pubSocket) Addr() net.Addr {
+	return pub.sck.Addr()
 }
 
 // GetOption is used to retrieve an option for a socket.

--- a/pull.go
+++ b/pull.go
@@ -6,6 +6,7 @@ package zmq4
 
 import (
 	"context"
+	"net"
 
 	"golang.org/x/xerrors"
 )
@@ -52,6 +53,12 @@ func (pull *pullSocket) Dial(ep string) error {
 // Type returns the type of this Socket (PUB, SUB, ...)
 func (pull *pullSocket) Type() SocketType {
 	return pull.sck.Type()
+}
+
+// Addr returns the listener's address.
+// Addr returns nil if the socket isn't a listener.
+func (pull *pullSocket) Addr() net.Addr {
+	return pull.sck.Addr()
 }
 
 // GetOption is used to retrieve an option for a socket.

--- a/push.go
+++ b/push.go
@@ -6,6 +6,7 @@ package zmq4
 
 import (
 	"context"
+	"net"
 
 	"golang.org/x/xerrors"
 )
@@ -52,6 +53,12 @@ func (push *pushSocket) Dial(ep string) error {
 // Type returns the type of this Socket (PUB, SUB, ...)
 func (push *pushSocket) Type() SocketType {
 	return push.sck.Type()
+}
+
+// Addr returns the listener's address.
+// Addr returns nil if the socket isn't a listener.
+func (push *pushSocket) Addr() net.Addr {
+	return push.sck.Addr()
 }
 
 // GetOption is used to retrieve an option for a socket.

--- a/rep.go
+++ b/rep.go
@@ -6,6 +6,7 @@ package zmq4
 
 import (
 	"context"
+	"net"
 )
 
 // NewRep returns a new REP ZeroMQ socket.
@@ -54,6 +55,12 @@ func (rep *repSocket) Dial(ep string) error {
 // Type returns the type of this Socket (PUB, SUB, ...)
 func (rep *repSocket) Type() SocketType {
 	return rep.sck.Type()
+}
+
+// Addr returns the listener's address.
+// Addr returns nil if the socket isn't a listener.
+func (rep *repSocket) Addr() net.Addr {
+	return rep.sck.Addr()
 }
 
 // GetOption is used to retrieve an option for a socket.

--- a/req.go
+++ b/req.go
@@ -6,6 +6,7 @@ package zmq4
 
 import (
 	"context"
+	"net"
 )
 
 // NewReq returns a new REQ ZeroMQ socket.
@@ -54,6 +55,12 @@ func (req *reqSocket) Dial(ep string) error {
 // Type returns the type of this Socket (PUB, SUB, ...)
 func (req *reqSocket) Type() SocketType {
 	return req.sck.Type()
+}
+
+// Addr returns the listener's address.
+// Addr returns nil if the socket isn't a listener.
+func (req *reqSocket) Addr() net.Addr {
+	return req.sck.Addr()
 }
 
 // GetOption is used to retrieve an option for a socket.

--- a/router.go
+++ b/router.go
@@ -7,6 +7,7 @@ package zmq4
 import (
 	"bytes"
 	"context"
+	"net"
 	"sync"
 
 	"golang.org/x/sync/errgroup"
@@ -57,6 +58,12 @@ func (router *routerSocket) Dial(ep string) error {
 // Type returns the type of this Socket (PUB, SUB, ...)
 func (router *routerSocket) Type() SocketType {
 	return router.sck.Type()
+}
+
+// Addr returns the listener's address.
+// Addr returns nil if the socket isn't a listener.
+func (router *routerSocket) Addr() net.Addr {
+	return router.sck.Addr()
 }
 
 // GetOption is used to retrieve an option for a socket.

--- a/socket.go
+++ b/socket.go
@@ -257,6 +257,15 @@ func (sck *socket) Type() SocketType {
 	return sck.typ
 }
 
+// Addr returns the listener's address.
+// Addr returns nil if the socket isn't a listener.
+func (sck *socket) Addr() net.Addr {
+	if sck.listener == nil {
+		return nil
+	}
+	return sck.listener.Addr()
+}
+
 // GetOption is used to retrieve an option for a socket.
 func (sck *socket) GetOption(name string) (interface{}, error) {
 	v, ok := sck.props[name]

--- a/sub.go
+++ b/sub.go
@@ -6,6 +6,7 @@ package zmq4
 
 import (
 	"context"
+	"net"
 	"sync"
 )
 
@@ -70,6 +71,12 @@ func (sub *subSocket) Dial(ep string) error {
 // Type returns the type of this Socket (PUB, SUB, ...)
 func (sub *subSocket) Type() SocketType {
 	return sub.sck.Type()
+}
+
+// Addr returns the listener's address.
+// Addr returns nil if the socket isn't a listener.
+func (sub *subSocket) Addr() net.Addr {
+	return sub.sck.Addr()
 }
 
 // GetOption is used to retrieve an option for a socket.

--- a/xpub.go
+++ b/xpub.go
@@ -6,6 +6,7 @@ package zmq4
 
 import (
 	"context"
+	"net"
 )
 
 // NewXPub returns a new XPUB ZeroMQ socket.
@@ -49,6 +50,12 @@ func (xpub *xpubSocket) Dial(ep string) error {
 // Type returns the type of this Socket (PUB, SUB, ...)
 func (xpub *xpubSocket) Type() SocketType {
 	return xpub.sck.Type()
+}
+
+// Addr returns the listener's address.
+// Addr returns nil if the socket isn't a listener.
+func (xpub *xpubSocket) Addr() net.Addr {
+	return xpub.sck.Addr()
 }
 
 // GetOption is used to retrieve an option for a socket.

--- a/xsub.go
+++ b/xsub.go
@@ -6,6 +6,7 @@ package zmq4
 
 import (
 	"context"
+	"net"
 )
 
 // NewXSub returns a new XSUB ZeroMQ socket.
@@ -49,6 +50,12 @@ func (xsub *xsubSocket) Dial(ep string) error {
 // Type returns the type of this Socket (PUB, SUB, ...)
 func (xsub *xsubSocket) Type() SocketType {
 	return xsub.sck.Type()
+}
+
+// Addr returns the listener's address.
+// Addr returns nil if the socket isn't a listener.
+func (xsub *xsubSocket) Addr() net.Addr {
+	return xsub.sck.Addr()
 }
 
 // GetOption is used to retrieve an option for a socket.

--- a/zmq4.go
+++ b/zmq4.go
@@ -7,6 +7,8 @@
 // For more informations, see http://zeromq.org.
 package zmq4
 
+import "net"
+
 // Socket represents a ZeroMQ socket.
 type Socket interface {
 	// Close closes the open Socket
@@ -27,6 +29,10 @@ type Socket interface {
 
 	// Type returns the type of this Socket (PUB, SUB, ...)
 	Type() SocketType
+
+	// Addr returns the listener's address.
+	// Addr returns nil if the socket isn't a listener.
+	Addr() net.Addr
 
 	// GetOption is used to retrieve an option for a socket.
 	GetOption(name string) (interface{}, error)


### PR DESCRIPTION
It's sometimes useful to listen to an ephemeral port assigned by the kernel, rather than a hardcoded one, for, for example, service discovery.

I've added a new method to the `Socket` interface to facilitate this which makes the following possible:
```go
pub = zmq4.NewPub(context.Background())
_ = pub.Listen("tcp://0.0.0.0:0")
addr := pub.Addr().String()
svcdisco.Register(addr)
```