### PR TITLE
zmq4: remove closed connections from pools

### DIFF
--- a/pub.go
+++ b/pub.go
@@ -82,7 +82,7 @@ type pubQReader struct {
 	ctx context.Context
 
 	mu sync.RWMutex
-	rs []*msgReader
+	rs []*Conn
 	c  chan Msg
 
 	sem *semaphore // ready when a connection is live.
@@ -111,7 +111,7 @@ func (q *pubQReader) Close() error {
 	return err
 }
 
-func (q *pubQReader) addConn(r *msgReader) {
+func (q *pubQReader) addConn(r *Conn) {
 	go q.listen(q.ctx, r)
 	q.mu.Lock()
 	q.sem.enable()
@@ -119,7 +119,7 @@ func (q *pubQReader) addConn(r *msgReader) {
 	q.mu.Unlock()
 }
 
-func (q *pubQReader) rmConn(r *msgReader) {
+func (q *pubQReader) rmConn(r *Conn) {
 	q.mu.Lock()
 	defer q.mu.Unlock()
 
@@ -144,23 +144,22 @@ func (q *pubQReader) read(ctx context.Context, msg *Msg) error {
 	return msg.err
 }
 
-func (q *pubQReader) listen(ctx context.Context, r *msgReader) {
+func (q *pubQReader) listen(ctx context.Context, r *Conn) {
 	defer q.rmConn(r)
 	defer r.Close()
 
 	for {
-		var msg Msg
-		err := r.read(ctx, &msg)
+		msg := r.read()
 		select {
 		case <-ctx.Done():
 			return
 		default:
-			if err != nil {
+			if msg.err != nil {
 				return
 			}
 			switch {
 			case q.topic(msg):
-				r.r.subscribe(msg)
+				r.subscribe(msg)
 			default:
 				q.c <- msg
 			}
@@ -183,7 +182,7 @@ func (q *pubQReader) topic(msg Msg) bool {
 type pubMWriter struct {
 	ctx context.Context
 	mu  sync.Mutex
-	ws  []*msgWriter
+	ws  []*Conn
 }
 
 func newPubMWriter(ctx context.Context) *pubMWriter {
@@ -206,13 +205,13 @@ func (w *pubMWriter) Close() error {
 	return err
 }
 
-func (mw *pubMWriter) addConn(w *msgWriter) {
+func (mw *pubMWriter) addConn(w *Conn) {
 	mw.mu.Lock()
 	mw.ws = append(mw.ws, w)
 	mw.mu.Unlock()
 }
 
-func (mw *pubMWriter) rmConn(w *msgWriter) {
+func (mw *pubMWriter) rmConn(w *Conn) {
 	mw.mu.Lock()
 	defer mw.mu.Unlock()
 
@@ -235,10 +234,14 @@ func (w *pubMWriter) write(ctx context.Context, msg Msg) error {
 	for i := range w.ws {
 		ww := w.ws[i]
 		grp.Go(func() error {
-			if !ww.w.subscribed(topic) {
+			if !ww.subscribed(topic) {
 				return nil
 			}
-			return ww.write(ctx, msg)
+			err := ww.SendMsg(msg)
+			if err != nil && ww.Closed() {
+				err = nil
+			}
+			return err
 		})
 	}
 	err := grp.Wait()

--- a/router.go
+++ b/router.go
@@ -81,7 +81,7 @@ type routerQReader struct {
 	ctx context.Context
 
 	mu sync.RWMutex
-	rs []*msgReader
+	rs []*Conn
 	c  chan Msg
 
 	sem *semaphore // ready when a connection is live.
@@ -110,7 +110,7 @@ func (q *routerQReader) Close() error {
 	return err
 }
 
-func (q *routerQReader) addConn(r *msgReader) {
+func (q *routerQReader) addConn(r *Conn) {
 	go q.listen(q.ctx, r)
 	q.mu.Lock()
 	q.sem.enable()
@@ -118,7 +118,7 @@ func (q *routerQReader) addConn(r *msgReader) {
 	q.mu.Unlock()
 }
 
-func (q *routerQReader) rmConn(r *msgReader) {
+func (q *routerQReader) rmConn(r *Conn) {
 	q.mu.Lock()
 	defer q.mu.Unlock()
 
@@ -143,19 +143,18 @@ func (q *routerQReader) read(ctx context.Context, msg *Msg) error {
 	return msg.err
 }
 
-func (q *routerQReader) listen(ctx context.Context, r *msgReader) {
+func (q *routerQReader) listen(ctx context.Context, r *Conn) {
 	defer q.rmConn(r)
 	defer r.Close()
 
-	id := []byte(r.r.Peer.Meta[sysSockID])
+	id := []byte(r.Peer.Meta[sysSockID])
 	for {
-		var msg Msg
-		err := r.read(ctx, &msg)
+		msg := r.read()
 		select {
 		case <-ctx.Done():
 			return
 		default:
-			if err != nil {
+			if msg.err != nil {
 				return
 			}
 			msg.Frames = append([][]byte{id}, msg.Frames...)
@@ -167,7 +166,7 @@ func (q *routerQReader) listen(ctx context.Context, r *msgReader) {
 type routerMWriter struct {
 	ctx context.Context
 	mu  sync.Mutex
-	ws  []*msgWriter
+	ws  []*Conn
 	sem *semaphore
 }
 
@@ -192,14 +191,14 @@ func (w *routerMWriter) Close() error {
 	return err
 }
 
-func (mw *routerMWriter) addConn(w *msgWriter) {
+func (mw *routerMWriter) addConn(w *Conn) {
 	mw.mu.Lock()
 	mw.sem.enable()
 	mw.ws = append(mw.ws, w)
 	mw.mu.Unlock()
 }
 
-func (mw *routerMWriter) rmConn(w *msgWriter) {
+func (mw *routerMWriter) rmConn(w *Conn) {
 	mw.mu.Lock()
 	defer mw.mu.Unlock()
 
@@ -223,12 +222,12 @@ func (w *routerMWriter) write(ctx context.Context, msg Msg) error {
 	dmsg := NewMsgFrom(msg.Frames[1:]...)
 	for i := range w.ws {
 		ww := w.ws[i]
-		pid := []byte(ww.w.Peer.Meta[sysSockID])
+		pid := []byte(ww.Peer.Meta[sysSockID])
 		if !bytes.Equal(pid, id) {
 			continue
 		}
 		grp.Go(func() error {
-			return ww.write(ctx, dmsg)
+			return ww.SendMsg(dmsg)
 		})
 	}
 	err := grp.Wait()

--- a/socket.go
+++ b/socket.go
@@ -264,7 +264,7 @@ func (sck *socket) rmConn(c *Conn) {
 	sck.mu.Lock()
 	defer sck.mu.Unlock()
 
-	cur := 0
+	cur := -1
 	for i := range sck.conns {
 		if sck.conns[i] == c {
 			cur = i

--- a/socket.go
+++ b/socket.go
@@ -48,6 +48,8 @@ type socket struct {
 	cancel   context.CancelFunc
 	listener net.Listener
 	dialer   net.Dialer
+
+	closedConns chan *Conn
 }
 
 func newDefaultSocket(ctx context.Context, sockType SocketType) *socket {
@@ -56,17 +58,18 @@ func newDefaultSocket(ctx context.Context, sockType SocketType) *socket {
 	}
 	ctx, cancel := context.WithCancel(ctx)
 	return &socket{
-		typ:    sockType,
-		retry:  defaultRetry,
-		sec:    nullSecurity{},
-		ids:    make(map[string]*Conn),
-		conns:  nil,
-		r:      newQReader(ctx),
-		w:      newMWriter(ctx),
-		props:  make(map[string]interface{}),
-		ctx:    ctx,
-		cancel: cancel,
-		dialer: net.Dialer{Timeout: defaultTimeout},
+		typ:         sockType,
+		retry:       defaultRetry,
+		sec:         nullSecurity{},
+		ids:         make(map[string]*Conn),
+		conns:       nil,
+		r:           newQReader(ctx),
+		w:           newMWriter(ctx),
+		props:       make(map[string]interface{}),
+		ctx:         ctx,
+		cancel:      cancel,
+		dialer:      net.Dialer{Timeout: defaultTimeout},
+		closedConns: make(chan *Conn),
 	}
 }
 
@@ -85,6 +88,10 @@ func newSocket(ctx context.Context, sockType SocketType, opts ...Option) *socket
 // Close closes the open Socket
 func (sck *socket) Close() error {
 	sck.cancel()
+	defer func() {
+		close(sck.closedConns)
+	}()
+
 	if sck.listener != nil {
 		defer sck.listener.Close()
 	}
@@ -155,6 +162,7 @@ func (sck *socket) Listen(endpoint string) error {
 	sck.listener = l
 
 	go sck.accept()
+	go sck.connReaper()
 
 	return nil
 }
@@ -173,7 +181,7 @@ func (sck *socket) accept() {
 				continue
 			}
 
-			zconn, err := Open(conn, sck.sec, sck.typ, sck.id, true)
+			zconn, err := Open(conn, sck.sec, sck.typ, sck.id, true, sck.scheduleRmConn)
 			if err != nil {
 				panic(err)
 				//		return xerrors.Errorf("zmq4: could not open a ZMTP connection: %w", err)
@@ -222,7 +230,7 @@ connect:
 		return xerrors.Errorf("zmq4: got a nil dial-conn to %q", endpoint)
 	}
 
-	zconn, err := Open(conn, sck.sec, sck.typ, sck.id, false)
+	zconn, err := Open(conn, sck.sec, sck.typ, sck.id, false, sck.scheduleRmConn)
 	if err != nil {
 		return xerrors.Errorf("zmq4: could not open a ZMTP connection: %w", err)
 	}
@@ -244,12 +252,43 @@ func (sck *socket) addConn(c *Conn) {
 	}
 	sck.ids[uuid] = c
 	if sck.r != nil {
-		sck.r.addConn(newMsgReader(c))
+		sck.r.addConn(c)
 	}
 	if sck.w != nil {
-		sck.w.addConn(newMsgWriter(c))
+		sck.w.addConn(c)
 	}
 	sck.mu.Unlock()
+}
+
+func (sck *socket) rmConn(c *Conn) {
+	sck.mu.Lock()
+	defer sck.mu.Unlock()
+
+	cur := 0
+	for i := range sck.conns {
+		if sck.conns[i] == c {
+			cur = i
+			break
+		}
+	}
+
+	if cur == -1 {
+		return
+	}
+
+	sck.conns = append(sck.conns[:cur], sck.conns[cur+1:]...)
+	if sck.r != nil {
+		sck.r.rmConn(c)
+	}
+	if sck.w != nil {
+		sck.w.rmConn(c)
+	}
+}
+
+func (sck *socket) scheduleRmConn(c *Conn) {
+	if sck.ctx.Err() != context.Canceled { // otherwise we've closed the chan
+		sck.closedConns <- c
+	}
 }
 
 // Type returns the type of this Socket (PUB, SUB, ...)
@@ -285,6 +324,16 @@ func (sck *socket) SetOption(name string, value interface{}) error {
 func (sck *socket) timeout() time.Duration {
 	// FIXME(sbinet): extract from options
 	return defaultTimeout
+}
+
+func (sck *socket) connReaper() {
+	for {
+		conn, ok := <-sck.closedConns
+		if !ok {
+			return
+		}
+		sck.rmConn(conn)
+	}
 }
 
 var (


### PR DESCRIPTION
Furthermore; do not return errors when publishing writes on closed connections.

Fixes go-zeromq/zmq4#39.


Basically,  rpool and wpool's add(rm)Conn methods were refactored to accept `*zmq4.Conn` so that `zmq4.socket` to be able to notify lower layers of closed connections.

All IO operations in `zmq4.Conn` are now guarded by a check to detect stale/closed connections. Once a closed connection is detected, the higher layer can then be notified via a configured close notification callback.