### PR TITLE
zmq4: Fix data race in socket.Close

### DIFF
--- a/socket.go
+++ b/socket.go
@@ -286,7 +286,7 @@ func (sck *socket) rmConn(c *Conn) {
 }
 
 func (sck *socket) scheduleRmConn(c *Conn) {
-	if sck.ctx.Err() != context.Canceled { // otherwise we've closed the chan
+	if sck.ctx.Err() == nil {
 		sck.closedConns <- c
 	}
 }


### PR DESCRIPTION
The data race manifests when the socket context's deadline has passed.

Fixes go-zeromq/zmq#50