### PR TITLE
zmq4: fix data races and deadlocks upon closed dial peers

### DIFF
--- a/conn.go
+++ b/conn.go
@@ -430,6 +430,11 @@ func (conn *Conn) checkIO(err error) {
 		return
 	}
 
+	if err == io.EOF || xerrors.Is(err, io.EOF) {
+		conn.SetClosed()
+		return
+	}
+
 	var e net.Error
 	if xerrors.As(err, &e); e != nil && !e.Timeout() {
 		conn.SetClosed()


### PR DESCRIPTION
Fixes the following bugs:

* Race condition on `socket.conns` when calling `Socket.Close` and the connReaper.
* Deadlocks when sending on `socket.closedConns` for a dial-only socket. The send blocks indefinitely because the connReaper wasn't  available to receive the closed connections.
* When checking for IO errors in conn.go, `io.EOF` wasn't being considered. This caused a connection to a dead PUB/PUSH/etc to be extant indefinitely.

`TestPubSubDeadPub` tests for the scenarios above.