### PR TITLE
zmq4: closing a socket with no peer is not an error

### DIFF
--- a/socket.go
+++ b/socket.go
@@ -23,7 +23,6 @@ const (
 
 var (
 	errInvalidAddress = xerrors.New("zmq4: invalid address")
-	errInvalidSocket  = xerrors.New("zmq4: invalid socket")
 
 	ErrBadProperty = xerrors.New("zmq4: bad property")
 )
@@ -98,9 +97,6 @@ func (sck *socket) Close() error {
 
 	sck.mu.RLock()
 	defer sck.mu.RUnlock()
-	if sck.conns == nil {
-		return errInvalidSocket
-	}
 
 	var err error
 	for _, conn := range sck.conns {

--- a/zmq4_pair_test.go
+++ b/zmq4_pair_test.go
@@ -65,13 +65,13 @@ func TestPair(t *testing.T) {
 			defer tc.srv.Close()
 			defer tc.cli.Close()
 
+			ep := tc.endpoint
+			cleanUp(ep)
+
 			if tc.skip {
 				t.Skipf(tc.name)
 			}
 			t.Parallel()
-
-			ep := tc.endpoint
-			cleanUp(ep)
 
 			var (
 				wg1 sync.WaitGroup

--- a/zmq4_pubsub_test.go
+++ b/zmq4_pubsub_test.go
@@ -103,13 +103,13 @@ func TestPubSub(t *testing.T) {
 			defer tc.sub1.Close()
 			defer tc.sub2.Close()
 
+			ep := tc.endpoint
+			cleanUp(ep)
+
 			if tc.skip {
 				t.Skipf(tc.name)
 			}
 			t.Parallel()
-
-			ep := tc.endpoint
-			cleanUp(ep)
 
 			ctx, timeout := context.WithTimeout(context.Background(), 20*time.Second)
 			defer timeout()

--- a/zmq4_pushpull_test.go
+++ b/zmq4_pushpull_test.go
@@ -58,13 +58,13 @@ func TestPushPull(t *testing.T) {
 			defer tc.pull.Close()
 			defer tc.push.Close()
 
+			ep := tc.endpoint
+			cleanUp(ep)
+
 			if tc.skip {
 				t.Skipf(tc.name)
 			}
 			t.Parallel()
-
-			ep := tc.endpoint
-			cleanUp(ep)
 
 			ctx, timeout := context.WithTimeout(context.Background(), 20*time.Second)
 			defer timeout()

--- a/zmq4_reqrep_test.go
+++ b/zmq4_reqrep_test.go
@@ -62,13 +62,13 @@ func TestReqRep(t *testing.T) {
 			defer tc.req.Close()
 			defer tc.rep.Close()
 
+			ep := tc.endpoint
+			cleanUp(ep)
+
 			if tc.skip {
 				t.Skipf(tc.name)
 			}
 			t.Parallel()
-
-			ep := tc.endpoint
-			cleanUp(ep)
 
 			ctx, timeout := context.WithTimeout(context.Background(), 20*time.Second)
 			defer timeout()

--- a/zmq4_routerdealer_test.go
+++ b/zmq4_routerdealer_test.go
@@ -239,3 +239,16 @@ func TestRouterDealer(t *testing.T) {
 		})
 	}
 }
+
+func TestRouterWithNoDealer(t *testing.T) {
+	router := zmq4.NewRouter(context.Background())
+	err := router.Listen("tcp://*:*")
+	if err != nil {
+		t.Fatalf("could not listen: %+v", err)
+	}
+
+	err = router.Close()
+	if err != nil {
+		t.Fatalf("could not close router: %+v", err)
+	}
+}

--- a/zmq4_routerdealer_test.go
+++ b/zmq4_routerdealer_test.go
@@ -94,12 +94,13 @@ func TestRouterDealer(t *testing.T) {
 	for i := range routerdealers {
 		tc := routerdealers[i]
 		t.Run(tc.name, func(t *testing.T) {
-			if tc.skip {
-				t.Skipf(tc.name)
-			}
 			t.Parallel()
 			ep := tc.endpoint()
 			cleanUp(ep)
+
+			if tc.skip {
+				t.Skipf(tc.name)
+			}
 
 			ctx, timeout := context.WithTimeout(context.Background(), 10*time.Second)
 			defer timeout()

--- a/zmq4_xpubsub_test.go
+++ b/zmq4_xpubsub_test.go
@@ -77,13 +77,13 @@ func TestXPubSub(t *testing.T) {
 			defer tc.sub1.Close()
 			defer tc.sub2.Close()
 
+			ep := tc.endpoint
+			cleanUp(ep)
+
 			if tc.skip {
 				t.Skipf(tc.name)
 			}
-			//t.Parallel()
-
-			ep := tc.endpoint
-			cleanUp(ep)
+			t.Parallel()
 
 			ctx, timeout := context.WithTimeout(context.Background(), 20*time.Second)
 			defer timeout()


### PR DESCRIPTION
This CL makes sockets that are closed before anybody else had time to
connect a non failing operation.

Fixes go-zeromq/zmq4#57.