### PR TITLE
zmq4: preserve dialed ipc socket when closing

### DIFF
--- a/socket.go
+++ b/socket.go
@@ -110,7 +110,9 @@ func (sck *socket) Close() error {
 			err = e
 		}
 	}
-	if strings.HasPrefix(sck.ep, "ipc://") {
+
+	// Remove the created unix socket file created by net.Listen
+	if sck.listener != nil && strings.HasPrefix(sck.ep, "ipc://") {
 		os.Remove(sck.ep[len("ipc://"):])
 	}
 

--- a/socket.go
+++ b/socket.go
@@ -111,7 +111,7 @@ func (sck *socket) Close() error {
 		}
 	}
 
-	// Remove the created unix socket file created by net.Listen
+	// Remove the unix socket file if created by net.Listen
 	if sck.listener != nil && strings.HasPrefix(sck.ep, "ipc://") {
 		os.Remove(sck.ep[len("ipc://"):])
 	}


### PR DESCRIPTION
When closing a dialed ipc socket, do not remove the socket file since we are not the server. Removing the unix socket file on disk only if net.Listen was used to create the file.