### PR TITLE
zmq4: some zmq client sends empty Identity in metadata

### DIFF
--- a/socket.go
+++ b/socket.go
@@ -38,7 +38,7 @@ type socket struct {
 	log   *log.Logger
 
 	mu    sync.RWMutex
-	conns []*Conn          // ZMTP connections
+	conns []*Conn // ZMTP connections
 	r     rpool
 	w     wpool
 


### PR DESCRIPTION
pyzmq, which is a python binding for the official C++ zmq library, sends empty identity in its metadata. According to 27/ZAP it seems that the identity field could be zero length. We can probably assign a new uuid in this case.

Additionally, remove `sck.ids`, which seems to be leaking and unused.