### PR TITLE
implement Topics() interface for xpub sockets

### DIFF
--- a/pub.go
+++ b/pub.go
@@ -7,7 +7,6 @@ package zmq4
 import (
 	"context"
 	"net"
-	"sort"
 	"sync"
 
 	"golang.org/x/xerrors"
@@ -113,25 +112,7 @@ func (pub *pubSocket) SetOption(name string, value interface{}) error {
 
 // Topics returns the sorted list of topics a socket is subscribed to.
 func (pub *pubSocket) Topics() []string {
-	var (
-		keys   = make(map[string]struct{})
-		topics []string
-	)
-	pub.sck.mu.RLock()
-	for _, con := range pub.sck.conns {
-		con.mu.RLock()
-		for topic := range con.topics {
-			if _, dup := keys[topic]; dup {
-				continue
-			}
-			keys[topic] = struct{}{}
-			topics = append(topics, topic)
-		}
-		con.mu.RUnlock()
-	}
-	pub.sck.mu.RUnlock()
-	sort.Strings(topics)
-	return topics
+	return pub.sck.topics()
 }
 
 // pubQReader is a queued-message reader.

--- a/xpub.go
+++ b/xpub.go
@@ -77,6 +77,10 @@ func (xpub *xpubSocket) SetOption(name string, value interface{}) error {
 	return xpub.sck.SetOption(name, value)
 }
 
+func (xpub *xpubSocket) Topics() []string {
+	return xpub.sck.topics()
+}
+
 var (
 	_ Socket = (*xpubSocket)(nil)
 )

--- a/zmq4_xpubsub_test.go
+++ b/zmq4_xpubsub_test.go
@@ -113,6 +113,11 @@ func TestXPubSub(t *testing.T) {
 
 				time.Sleep(1 * time.Second)
 
+				gotTopics := tc.xpub.(zmq4.Topics).Topics()
+				if !reflect.DeepEqual(gotTopics, topics) {
+					t.Fatalf("Missing or wrong topics.\ngot= %q\nwant=%q", gotTopics, topics)
+				}
+
 				for _, msg := range msgs[0] {
 					err = tc.xpub.Send(msg)
 					if err != nil {


### PR DESCRIPTION
I was developing a way to determine if an xpub socket had already got its list of topics from a zmq proxy and saw that this was missing. I moved the method to the socket struct so it could be used from pub and xpub sockets.