### PR TITLE
#85 Added a DialContext method to all sockets.

### DIFF
--- a/conn.go
+++ b/conn.go
@@ -21,6 +21,7 @@ var ErrClosedConn = errors.New("zmq4: read/write on closed connection")
 // Conn implements the ZeroMQ Message Transport Protocol as defined
 // in https://rfc.zeromq.org/spec:23/ZMTP/.
 type Conn struct {
+	ep     string
 	typ    SocketType
 	id     SocketIdentity
 	rw     net.Conn
@@ -64,7 +65,15 @@ func (c *Conn) Write(p []byte) (int, error) {
 // Open opens a ZMTP connection over rw with the given security, socket type and identity.
 // An optional onCloseErrorCB can be provided to inform the caller when this Conn is closed.
 // Open performs a complete ZMTP handshake.
-func Open(rw net.Conn, sec Security, sockType SocketType, sockID SocketIdentity, server bool, onCloseErrorCB func(c *Conn)) (*Conn, error) {
+func Open(
+	ep string,
+	rw net.Conn,
+	sec Security,
+	sockType SocketType,
+	sockID SocketIdentity,
+	server bool,
+	onCloseErrorCB func(c *Conn),
+) (*Conn, error) {
 	if rw == nil {
 		return nil, fmt.Errorf("zmq4: invalid nil read-writer")
 	}
@@ -74,6 +83,7 @@ func Open(rw net.Conn, sec Security, sockType SocketType, sockID SocketIdentity,
 	}
 
 	conn := &Conn{
+		ep:             ep,
 		typ:            sockType,
 		id:             sockID,
 		rw:             rw,

--- a/dealer.go
+++ b/dealer.go
@@ -54,6 +54,11 @@ func (dealer *dealerSocket) Dial(ep string) error {
 	return dealer.sck.Dial(ep)
 }
 
+// Dial connects a remote endpoint to the Socket.
+func (dealer *dealerSocket) DialContext(ctx context.Context, ep string) error {
+	return dealer.sck.DialContext(ctx, ep)
+}
+
 // Type returns the type of this Socket (PUB, SUB, ...)
 func (dealer *dealerSocket) Type() SocketType {
 	return dealer.sck.Type()

--- a/msgio.go
+++ b/msgio.go
@@ -50,7 +50,7 @@ func newQReader(ctx context.Context) *qreader {
 }
 
 func (q *qreader) Close() error {
-	q.mu.RLock()
+	q.mu.Lock()
 	var err error
 	var grp errgroup.Group
 	for i := range q.rs {
@@ -58,7 +58,7 @@ func (q *qreader) Close() error {
 	}
 	err = grp.Wait()
 	q.rs = nil
-	q.mu.RUnlock()
+	q.mu.Unlock()
 	return err
 }
 

--- a/pair.go
+++ b/pair.go
@@ -54,6 +54,11 @@ func (pair *pairSocket) Dial(ep string) error {
 	return pair.sck.Dial(ep)
 }
 
+// DialContext connects a remote endpoint to the Socket.
+func (pair *pairSocket) DialContext(ctx context.Context, ep string) error {
+	return pair.sck.DialContext(ctx, ep)
+}
+
 // Type returns the type of this Socket (PUB, SUB, ...)
 func (pair *pairSocket) Type() SocketType {
 	return pair.sck.Type()

--- a/pub.go
+++ b/pub.go
@@ -70,6 +70,11 @@ func (pub *pubSocket) Dial(ep string) error {
 	return pub.sck.Dial(ep)
 }
 
+// DialContext connects a remote endpoint to the Socket.
+func (pub *pubSocket) DialContext(ctx context.Context, ep string) error {
+	return pub.sck.DialContext(ctx, ep)
+}
+
 // Type returns the type of this Socket (PUB, SUB, ...)
 func (pub *pubSocket) Type() SocketType {
 	return pub.sck.Type()

--- a/pull.go
+++ b/pull.go
@@ -56,6 +56,11 @@ func (pull *pullSocket) Dial(ep string) error {
 	return pull.sck.Dial(ep)
 }
 
+// DialContext connects a remote endpoint to the Socket.
+func (pull *pullSocket) DialContext(ctx context.Context, ep string) error {
+	return pull.sck.DialContext(ctx, ep)
+}
+
 // Type returns the type of this Socket (PUB, SUB, ...)
 func (pull *pullSocket) Type() SocketType {
 	return pull.sck.Type()

--- a/push.go
+++ b/push.go
@@ -56,6 +56,11 @@ func (push *pushSocket) Dial(ep string) error {
 	return push.sck.Dial(ep)
 }
 
+// DialContext connects a remote endpoint to the Socket.
+func (push *pushSocket) DialContext(ctx context.Context, ep string) error {
+	return push.sck.DialContext(ctx, ep)
+}
+
 // Type returns the type of this Socket (PUB, SUB, ...)
 func (push *pushSocket) Type() SocketType {
 	return push.sck.Type()

--- a/rep.go
+++ b/rep.go
@@ -71,6 +71,11 @@ func (rep *repSocket) Dial(ep string) error {
 	return rep.sck.Dial(ep)
 }
 
+// DialContext connects a remote endpoint to the Socket.
+func (rep *repSocket) DialContext(ctx context.Context, ep string) error {
+	return rep.sck.DialContext(ctx, ep)
+}
+
 // Type returns the type of this Socket (PUB, SUB, ...)
 func (rep *repSocket) Type() SocketType {
 	return rep.sck.Type()

--- a/req.go
+++ b/req.go
@@ -69,6 +69,11 @@ func (req *reqSocket) Dial(ep string) error {
 	return req.sck.Dial(ep)
 }
 
+// DialContext connects a remote endpoint to the Socket.
+func (req *reqSocket) DialContext(ctx context.Context, ep string) error {
+	return req.sck.DialContext(ctx, ep)
+}
+
 // Type returns the type of this Socket (PUB, SUB, ...)
 func (req *reqSocket) Type() SocketType {
 	return req.sck.Type()

--- a/router.go
+++ b/router.go
@@ -63,6 +63,11 @@ func (router *routerSocket) Dial(ep string) error {
 	return router.sck.Dial(ep)
 }
 
+// DialContext connects a remote endpoint to the Socket.
+func (router *routerSocket) DialContext(ctx context.Context, ep string) error {
+	return router.sck.DialContext(ctx, ep)
+}
+
 // Type returns the type of this Socket (PUB, SUB, ...)
 func (router *routerSocket) Type() SocketType {
 	return router.sck.Type()

--- a/sub.go
+++ b/sub.go
@@ -58,11 +58,12 @@ func (sub *subSocket) Listen(ep string) error {
 
 // Dial connects a remote endpoint to the Socket.
 func (sub *subSocket) Dial(ep string) error {
-	err := sub.sck.Dial(ep)
-	if err != nil {
-		return err
-	}
-	return nil
+	return sub.sck.Dial(ep)
+}
+
+// DialContext connects a remote endpoint to the Socket.
+func (sub *subSocket) DialContext(ctx context.Context, ep string) error {
+	return sub.sck.DialContext(ctx, ep)
 }
 
 // Type returns the type of this Socket (PUB, SUB, ...)

--- a/xpub.go
+++ b/xpub.go
@@ -56,6 +56,11 @@ func (xpub *xpubSocket) Dial(ep string) error {
 	return xpub.sck.Dial(ep)
 }
 
+// DialContext connects a remote endpoint to the Socket.
+func (xpub *xpubSocket) DialContext(ctx context.Context, ep string) error {
+	return xpub.sck.DialContext(ctx, ep)
+}
+
 // Type returns the type of this Socket (PUB, SUB, ...)
 func (xpub *xpubSocket) Type() SocketType {
 	return xpub.sck.Type()

--- a/xsub.go
+++ b/xsub.go
@@ -54,6 +54,11 @@ func (xsub *xsubSocket) Dial(ep string) error {
 	return xsub.sck.Dial(ep)
 }
 
+// DialContext connects a remote endpoint to the Socket.
+func (xsub *xsubSocket) DialContext(ctx context.Context, ep string) error {
+	return xsub.sck.DialContext(ctx, ep)
+}
+
 // Type returns the type of this Socket (PUB, SUB, ...)
 func (xsub *xsubSocket) Type() SocketType {
 	return xsub.sck.Type()

--- a/zmq4.go
+++ b/zmq4.go
@@ -7,7 +7,10 @@
 // For more informations, see http://zeromq.org.
 package zmq4
 
-import "net"
+import (
+	"context"
+	"net"
+)
 
 // Socket represents a ZeroMQ socket.
 type Socket interface {
@@ -31,6 +34,9 @@ type Socket interface {
 
 	// Dial connects a remote endpoint to the Socket.
 	Dial(ep string) error
+
+	// Dial connects a remote endpoint to the Socket.
+	DialContext(ctx context.Context, ep string) error
 
 	// Type returns the type of this Socket (PUB, SUB, ...)
 	Type() SocketType


### PR DESCRIPTION

Fixes #85 Made Dial use the sockets default timeout (uses DialContext now).
Addjusted some tests to use DialContext.
Added TestNullHandshakeRRFail.
Added DialContext method to Socket interface and all sockets.

The timeout is now based on the context, simplified the waiting.