### PR TITLE
Ensure reaperCond is unlocked when context is canceled

### DIFF
--- a/socket.go
+++ b/socket.go
@@ -357,19 +357,22 @@ func (sck *socket) timeout() time.Duration {
 }
 
 func (sck *socket) connReaper() {
+	sck.reaperCond.L.Lock()
+	defer sck.reaperCond.L.Unlock()
+
 	for {
-		sck.reaperCond.L.Lock()
 		for len(sck.closedConns) == 0 && sck.ctx.Err() == nil {
 			sck.reaperCond.Wait()
 		}
+
 		if sck.ctx.Err() != nil {
 			return
 		}
+
 		for _, c := range sck.closedConns {
 			sck.rmConn(c)
 		}
 		sck.closedConns = nil
-		sck.reaperCond.L.Unlock()
 	}
 }
 


### PR DESCRIPTION
The previous PR (#106) failed to unlock `reaperCond.L` when the context was done, which causes deadlocks in certain circumstances. The new structure ensures the lock is always released, while also avoiding spurious `Lock()/Unlock()` calls (note that `reaperCond.Wait()` [atomically unlocks](https://pkg.go.dev/sync@go1.15.13#Cond.Wait) before entering its wait state).