### PR TITLE
Add context to semaphore

### DIFF
--- a/pub.go
+++ b/pub.go
@@ -173,7 +173,7 @@ func (q *pubQReader) rmConn(r *Conn) {
 }
 
 func (q *pubQReader) read(ctx context.Context, msg *Msg) error {
-	q.sem.lock()
+	q.sem.lock(ctx)
 	select {
 	case <-ctx.Done():
 	case *msg = <-q.c:

--- a/router.go
+++ b/router.go
@@ -143,7 +143,7 @@ func (q *routerQReader) rmConn(r *Conn) {
 }
 
 func (q *routerQReader) read(ctx context.Context, msg *Msg) error {
-	q.sem.lock()
+	q.sem.lock(ctx)
 	select {
 	case <-ctx.Done():
 		return ctx.Err()
@@ -224,7 +224,7 @@ func (mw *routerMWriter) rmConn(w *Conn) {
 }
 
 func (w *routerMWriter) write(ctx context.Context, msg Msg) error {
-	w.sem.lock()
+	w.sem.lock(ctx)
 	grp, _ := errgroup.WithContext(ctx)
 	w.mu.Lock()
 	id := msg.Frames[0]


### PR DESCRIPTION
Currently `semaphore` will block a `qreader` read from exiting even when the context have been canceled. From what I can tell its purpose is to guarantee there is a connection first (from `addConn`) before the read could proceed. However, this requirement makes it hard to write unit tests that might be blocked on waiting for the context to finish.

This change adds context into the semaphore so that read can be unblocked when the context is canceled, instead of resulting in a deadlock.