### PR TITLE
Clarify docs a bit about how Listen() and Dial() translate to bind() and connect()

### DIFF
--- a/zmq4.go
+++ b/zmq4.go
@@ -11,37 +11,43 @@ import "net"
 
 // Socket represents a ZeroMQ socket.
 type Socket interface {
-	// Close closes the open Socket
+	// Close closes the open Socket.
 	Close() error
 
 	// Send puts the message on the outbound send queue.
+	//
 	// Send blocks until the message can be queued or the send deadline expires.
 	Send(msg Msg) error
 
 	// SendMulti puts the message on the outbound send queue.
-	// SendMulti blocks until the message can be queued or the send deadline expires.
-	// The message will be sent as a multipart message.
+	//
+	// SendMulti blocks until the message can be queued or the send deadline
+	// expires. The message will be sent as a multipart message.
 	SendMulti(msg Msg) error
 
 	// Recv receives a complete message.
 	Recv() (Msg, error)
 
 	// Listen connects a local endpoint to the Socket.
+	//
+	// In ZeroMQ's terminology, it binds.
 	Listen(ep string) error
 
 	// Dial connects a remote endpoint to the Socket.
+	//
+	// In ZeroMQ's terminology, it connects.
 	Dial(ep string) error
 
-	// Type returns the type of this Socket (PUB, SUB, ...)
+	// Type returns the type of this Socket (for example PUB, SUB, etc.)
 	Type() SocketType
 
-	// Addr returns the listener's address.
-	// Addr returns nil if the socket isn't a listener.
+	// Addr returns the listener's address. It returns nil if the socket isn't a
+	// listener.
 	Addr() net.Addr
 
-	// GetOption is used to retrieve an option for a socket.
+	// GetOption retrieves an option for a socket.
 	GetOption(name string) (interface{}, error)
 
-	// SetOption is used to set an option for a socket.
+	// SetOption sets an option for a socket.
 	SetOption(name string, value interface{}) error
 }


### PR DESCRIPTION
I've lost some time when trying to build a very simple pub-sub (without looking at the examples).

I called `Socket.Listen()` in my sub, and `Socket.Dial()` on my pub. It had to be reversed to work. I thought docs could clarify this.

Also, I think it a bit confusing that my publisher calls `Listen()`, as if it was listening for messages. Why was this named like this? 