### PR TITLE
Fix rep cancellation

### DIFF
--- a/rep.go
+++ b/rep.go
@@ -258,6 +258,8 @@ func (r *repWriter) rmConn(conn *Conn) {
 func (r *repWriter) write(ctx context.Context, msg Msg) error {
 	conn, preamble := r.state.Get()
 	select {
+	case <-ctx.Done():
+		return ctx.Err()
 	case <-r.ctx.Done(): // repWriter.run() terminates on this, sendCh <- will not complete
 		return r.ctx.Err()
 	case r.sendCh <- repSendPayload{conn, preamble, msg}:

--- a/rep.go
+++ b/rep.go
@@ -257,8 +257,12 @@ func (r *repWriter) rmConn(conn *Conn) {
 
 func (r *repWriter) write(ctx context.Context, msg Msg) error {
 	conn, preamble := r.state.Get()
-	r.sendCh <- repSendPayload{conn, preamble, msg}
-	return nil
+	select {
+	case <-r.ctx.Done(): // repWriter.run() terminates on this, sendCh <- will not complete
+		return r.ctx.Err()
+	case r.sendCh <- repSendPayload{conn, preamble, msg}:
+		return nil
+	}
 }
 
 func (r *repWriter) run() {


### PR DESCRIPTION
I have found a race condition in the ctx cancellation in `repWriter`. 

Added a test which reproduces the issue with a possible fix. 

I don't quite understand why dont we use `ctx` in the  write routine, see my second commit about that.