### PR TITLE
added default hwm and per-subscriber queues

### DIFF
--- a/pub.go
+++ b/pub.go
@@ -240,8 +240,9 @@ func (w *pubMWriter) Close() error {
 	w.mu.Lock()
 	defer w.mu.Unlock()
 
-	for conn := range w.subscribers {
+	for conn, channel := range w.subscribers {
 		_ = conn.Close()
+		close(channel)
 	}
 	w.subscribers = nil
 	return nil

--- a/pub.go
+++ b/pub.go
@@ -241,8 +241,9 @@ func (w *pubMWriter) Close() error {
 	defer w.mu.Unlock()
 
 	for conn := range w.subscribers {
-		w.rmConn(conn)
+		_ = conn.Close()
 	}
+	w.subscribers = nil
 	return nil
 }
 
@@ -281,7 +282,7 @@ func (w *pubMWriter) write(ctx context.Context, msg Msg) error {
 		select {
 		case <-ctx.Done():
 			return ctx.Err()
-		case channel <- msg: // will block if the channel is full
+		case channel <- msg: // proceeds to default case if the channel is full (msg will be discarded)
 		default:
 		}
 	}


### PR DESCRIPTION
Hey! I'm a fan of this library. A couple of tweaks:

- Default high-water mark:
    * The HWM is currently set to zero, which allows the queue to grow infinitely - https://github.com/go-zeromq/zmq4/issues/151.
    * The spec states that we ["SHOULD constrain queue sizes to a runtime-configurable limit"](https://rfc.zeromq.org/spec/29/#the-pub-socket-type). In libzmq, the [default is 1000](https://libzmq.readthedocs.io/en/latest/zmq_setsockopt.html), so that seemed like a sensible choice. Side note, there was a TODO to allow for "per subscriber hwm". The zmq docs are a bit vague in some places but it seems like it's supposed to be per-socket rather than per-subscriber.
    * This allows us to use Go's buffered channels instead of `Queue`.
- Per-subscriber queues:
    * Currently, the pub socket maintains a single outbound queue, which can cause issues (e.g. what happens if a single connection hangs?)
    * Instead, we can spawn a goroutine for each `Conn` added. This also address [this TODO](https://github.com/go-zeromq/zmq4/blob/60c2bc1615b49c7910403cd4afb5f29dac8bca2f/pub.go#L315).
    * Again looking at the spec: we ["SHALL maintain a single outgoing message queue for each connected subscriber"](https://rfc.zeromq.org/spec/29/#the-pub-socket-type).

